### PR TITLE
feat: disable Vercel caching for payment order status endpoint

### DIFF
--- a/src/app/api/payment/order-status/[orderId]/route.ts
+++ b/src/app/api/payment/order-status/[orderId]/route.ts
@@ -12,7 +12,14 @@ export async function GET(
       return NextResponse.json({
         success: false,
         error: '订单ID不能为空'
-      }, { status: 400 })
+      }, { 
+        status: 400,
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0'
+        }
+      })
     }
 
     // 查找订单
@@ -22,7 +29,14 @@ export async function GET(
       return NextResponse.json({
         success: false,
         error: '订单不存在'
-      }, { status: 404 })
+      }, { 
+        status: 404,
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0'
+        }
+      })
     }
 
     return NextResponse.json({
@@ -37,6 +51,12 @@ export async function GET(
         paidAt: order.paidAt,
         metadata: order.metadata
       }
+    }, {
+      headers: {
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Pragma': 'no-cache',
+        'Expires': '0'
+      }
     })
 
   } catch (error) {
@@ -44,6 +64,13 @@ export async function GET(
     return NextResponse.json({
       success: false,
       error: '服务器错误'
-    }, { status: 500 })
+    }, { 
+      status: 500,
+      headers: {
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Pragma': 'no-cache',
+        'Expires': '0'
+      }
+    })
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,24 @@
     "src/app/api/*": {
       "maxDuration": 30
     }
-  }
+  },
+  "headers": [
+    {
+      "source": "/api/payment/order-status/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        },
+        {
+          "key": "Pragma", 
+          "value": "no-cache"
+        },
+        {
+          "key": "Expires",
+          "value": "0"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Fixes #9

Disables Vercel caching for the `/payment/order-status/` endpoint to ensure real-time payment status checking.

**Changes:**
- Added cache control headers to all API responses in order-status endpoint
- Configured vercel.json to prevent caching of `/api/payment/order-status/` routes
- Ensures real-time payment status checking without cache interference

Generated with [Claude Code](https://claude.ai/code)